### PR TITLE
fix(init.js): silently handles exceptions thrown by child_process

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -33,7 +33,12 @@ const safePackageName = str =>
 
 const trim = str => str.replace(/^\s|\s$/, '');
 
-const exec = cmd =>
-  trim(execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString());
+const exec = cmd => {
+  try {
+    trim(execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString());
+  } catch {
+    return false;
+  }
+};
 
 export { exists, read, write, safePackageName, exec };


### PR DESCRIPTION
If a user doesn't have a github.user field in their .gitconfig, `klap init` will currently throw an exception and halt. The fallback of `user.name` is not reached in any case. This commit addresses the issue by adding `try...catch` blocks to silently catch the exceptions.

It also omits adding the undefined properties to `package.json` in favor of letting the author handle them manually, meaning, no `author` field will be generated by klap.

There may be a better way to handle this, such as alerting the user (since they might like to know if they don't have a properly configured .gitconfig), but I'll leave that up to you! 👏

fix #27