### PR TITLE
feat: Add cli options for output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Then use `npm run` or `yarn` to invoke npm scripts as you normally would.
 | option              | cli flag(s)           | description                                    | default                           |
 | ------------------- | --------------------- | ---------------------------------------------- | --------------------------------- |
 | `source`            | -s&nbsp;--source      | source file to compile and bundle              | `src/index.js`                    |
+|                     | --node                | the output file to write the cjs file to       | pkg.main                          |
+|                     | --module              | the output file to write the esm file to       | pkg.module                        |
+|                     | --browser             | the output file to write the umd file to       | pkg.browser                       |
 | `browserslist`      | -b&nbsp;--browserlist | browserlist compatible compilation target      | `>1%, not ie 11, not op_mini all` |
 | `klap.name`         | -n&nbsp;--name        | package name for `umd` bundles                 | sanitized `pkg.name`              |
 | `klap.port`         | -p&nbsp;--port        | port for development server                    | `1234`                            |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Then use `npm run` or `yarn` to invoke npm scripts as you normally would.
 | option              | cli flag(s)           | description                                    | default                           |
 | ------------------- | --------------------- | ---------------------------------------------- | --------------------------------- |
 | `source`            | -s&nbsp;--source      | source file to compile and bundle              | `src/index.js`                    |
-|                     | --node                | the output file to write the cjs file to       | pkg.main                          |
+|                     | --main                | the output file to write the cjs file to       | pkg.main                          |
 |                     | --module              | the output file to write the esm file to       | pkg.module                        |
 |                     | --browser             | the output file to write the umd file to       | pkg.browser                       |
 | `browserslist`      | -b&nbsp;--browserlist | browserlist compatible compilation target      | `>1%, not ie 11, not op_mini all` |

--- a/src/klap.js
+++ b/src/klap.js
@@ -1,5 +1,5 @@
 import del from 'del';
-import { dirname } from 'path';
+import { dirname, basename } from 'path';
 import { rollup, watch } from 'rollup';
 import { error, info, log } from './logger';
 import { getOptions } from './options';
@@ -113,11 +113,17 @@ const startConfig = async (command, pkg, options) => {
   return { inputOptions, outputOptions };
 };
 
-const deleteDirs = async pkg => {
+const deleteDirs = async (pkg, options) => {
   const dirs = {};
-  ['main', 'module', 'browser'].map(
-    type => pkg[type] && (dirs[dirname(pkg[type]) + '/*.{js,map}'] = true)
-  );
+  if(options.source == pkg.source) {
+    ['main', 'module', 'browser'].map(
+      type => pkg[type] && (dirs[dirname(pkg[type]) + "/" + basename(pkg[type], "js") + '.{js,map}'] = true)
+    );
+  } else {
+    ['node', 'module', 'browser'].map(
+      type => pkg[type] && (dirs[dirname(options[type]) + "/" + basename(options[type], "js") + '.{js,map}'] = true)
+    );
+  }
   await del(Object.keys(dirs));
 };
 
@@ -151,7 +157,7 @@ const processWatcher = event => {
 
 const klap = async (command, pkg) => {
   const options = getOptions(pkg);
-  await deleteDirs(pkg);
+  await deleteDirs(pkg, options);
   let config, watchOptions, watcher;
   switch (command) {
     case 'build':

--- a/src/klap.js
+++ b/src/klap.js
@@ -21,14 +21,16 @@ const validateConfig = (inputOptions, outputOptions) => {
 };
 
 const buildConfig = (command, pkg, options) => {
+  const { dependencies = {}, peerDependencies = {} } = pkg;
   const {
-    dependencies = {},
-    peerDependencies = {},
-    main,
+    name,
+    globals,
+    source: input,
+    node: main,
     module,
     browser,
-  } = pkg;
-  const { name, globals, source: input, sourcemap } = options;
+    sourcemap,
+  } = options;
   const external = Object.keys({ ...dependencies, ...peerDependencies });
 
   let inputOptions = [
@@ -68,8 +70,16 @@ const buildConfig = (command, pkg, options) => {
 };
 
 const startConfig = async (command, pkg, options) => {
-  const { module, browser } = pkg;
-  const { name, globals, example, source, sourcemap, target } = options;
+  const {
+    name,
+    globals,
+    example,
+    source,
+    module,
+    browser,
+    sourcemap,
+    target,
+  } = options;
   const input = (await exists(example)) ? example : source;
   let inputOptions, outputOptions;
   if (target === 'es') {

--- a/src/klap.js
+++ b/src/klap.js
@@ -26,7 +26,7 @@ const buildConfig = (command, pkg, options) => {
     name,
     globals,
     source: input,
-    node: main,
+    main,
     module,
     browser,
     sourcemap,
@@ -113,17 +113,11 @@ const startConfig = async (command, pkg, options) => {
   return { inputOptions, outputOptions };
 };
 
-const deleteDirs = async (pkg, options) => {
+const deleteDirs = async (options) => {
   const dirs = {};
-  if(options.source == pkg.source) {
-    ['main', 'module', 'browser'].map(
-      type => pkg[type] && (dirs[dirname(pkg[type]) + "/" + basename(pkg[type], "js") + '.{js,map}'] = true)
-    );
-  } else {
-    ['node', 'module', 'browser'].map(
-      type => pkg[type] && (dirs[dirname(options[type]) + "/" + basename(options[type], "js") + '.{js,map}'] = true)
-    );
-  }
+  ['main', 'module', 'browser'].map(
+    type => options[type] && (dirs[dirname(options[type]) + "/" + basename(options[type], "js") + '.{js,map}'] = true)
+  );
   await del(Object.keys(dirs));
 };
 
@@ -157,7 +151,7 @@ const processWatcher = event => {
 
 const klap = async (command, pkg) => {
   const options = getOptions(pkg);
-  await deleteDirs(pkg, options);
+  await deleteDirs(options);
   let config, watchOptions, watcher;
   switch (command) {
     case 'build':

--- a/src/options.js
+++ b/src/options.js
@@ -6,6 +6,9 @@ const getOptions = pkg => {
     klap = {},
     source = 'src/index.js',
     browserlist = '>1%, not ie 11, not op_mini all',
+    main,
+    module,
+    browser,
   } = pkg;
   const {
     name = pkg.name,
@@ -18,7 +21,7 @@ const getOptions = pkg => {
     fallback = 'public/index.html',
     example = 'public/index.js',
   } = klap;
-  const opts = getopts(process.argv.slice(2), {
+  const opts = getopts(process.argv.slice(3), {
     boolean: ['sourcemap', 'minify'],
     alias: {
       name: 'n',
@@ -29,6 +32,7 @@ const getOptions = pkg => {
       example: 'e',
       browserlist: 'b',
     },
+    string: ['node', 'browser', 'module'],
     default: {
       name: safePackageName(name),
       source,
@@ -41,6 +45,14 @@ const getOptions = pkg => {
       browserlist,
     },
   });
+
+  // If no specific target is given, build the standard outputs
+  if (!opts.node && !opts.module && !opts.browser) {
+    opts.node = main;
+    opts.module = module;
+    opts.browser = browser;
+  }
+
   return { ...opts, globals, namedExports };
 };
 

--- a/src/options.js
+++ b/src/options.js
@@ -32,7 +32,7 @@ const getOptions = pkg => {
       example: 'e',
       browserlist: 'b',
     },
-    string: ['node', 'browser', 'module'],
+    string: ['main', 'browser', 'module'],
     default: {
       name: safePackageName(name),
       source,
@@ -47,8 +47,8 @@ const getOptions = pkg => {
   });
 
   // If no specific target is given, build the standard outputs
-  if (!opts.node && !opts.module && !opts.browser) {
-    opts.node = main;
+  if (!opts.main && !opts.module && !opts.browser) {
+    opts.main = main;
     opts.module = module;
     opts.browser = browser;
   }


### PR DESCRIPTION
The PR allows to specify output files via the cli. This allows for multiple entry points, as [described here](https://github.com/developit/microbundle/issues/545).

To generate an entirely new bundle you would do something like the following:

`klap build --source src/sub.js --module dist/sub.esm.js --node dist/sub.js --browser dist/sub.umd.js` 