### PR TITLE
feat: adds support for typescript transformers when usets is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
 		"terser": "5.10.0",
 		"typescript": "^4.5.5",
 		"xo": "0.47.0",
-		"xo-quick": "0.0.9"
+		"xo-quick": "0.0.9",
+		"ttypescript": "1.5.13"
 	}
 }

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -27,7 +27,9 @@ const plugins = (command, pkg, options) => {
 			extensions,
 		}),
 		commonjs({ extensions, include: /\/node_modules\// }),
-		usets && require('@rollup/plugin-typescript')(),
+		usets && require('@rollup/plugin-typescript')({
+			typescript: require("ttypescript")
+		}),
 		babel({
 			...babelDefaults,
 			exclude: 'node_modules/**',


### PR DESCRIPTION
This change adds the `ttypescript` module to this project and integrates with `rollup` so everyone that uses it with typescript can add Typescript transformers without having to change anything. It will just work seamlessly by reading the tsconfig.json's compilerOptions.plugins section as it is meant to do.